### PR TITLE
Merge Changes to insert atom feature (#899)

### DIFF
--- a/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertAtoms.cpp
+++ b/Source/Plugins/SyntheticBuilding/SyntheticBuildingFilters/InsertAtoms.cpp
@@ -132,7 +132,7 @@ public:
           code = GeometryMath::PointInPolyhedron(m_Faces.get(), faceIds, m_FaceBBs.get(), point, ll, ur, radius);
           if(code == 'i' || code == 'V' || code == 'E' || code == 'F')
           {
-            m_InFeature[start]->setValue(i, true);
+            m_InFeature[iter]->setValue(i, true);
           }
         }
       }
@@ -179,6 +179,10 @@ public:
     {
       atomMult = 4;
     }
+    if(basis == 3)
+    {
+      atomMult = 8;
+    }
     int64_t xPoints = (int64_t(deltaX / latticeConstants.x) + 1);
     int64_t yPoints = (int64_t(deltaY / latticeConstants.y) + 1);
     int64_t zPoints = (int64_t(deltaZ / latticeConstants.z) + 1);
@@ -204,32 +208,63 @@ public:
           count++;
           if(basis == 1)
           {
-            coords[0] = coords[0] + (0.5 * latticeConstants.x);
-            coords[1] = coords[1] + (0.5 * latticeConstants.y);
-            coords[2] = coords[2] + (0.5 * latticeConstants.z);
+            coords[0] = coords[0] + (0.5f * latticeConstants.x);
+            coords[1] = coords[1] + (0.5f * latticeConstants.y);
+            coords[2] = coords[2] + (0.5f * latticeConstants.z);
             MatrixMath::Multiply3x3with3x1(gT, coords, coordsT);
             points[iter]->setCoords(count, coordsT);
             count++;
           }
-          if(basis == 2)
+          if(basis == 2||3)
           {
             // makes the (0.5,0.5,0) atom
-            coords[0] = coords[0] + (0.5 * latticeConstants.x);
-            coords[1] = coords[1] + (0.5 * latticeConstants.y);
+            coords[0] = coords[0] + (0.5f * latticeConstants.x);
+            coords[1] = coords[1] + (0.5f * latticeConstants.y);
             coords[2] = coords[2];
             MatrixMath::Multiply3x3with3x1(gT, coords, coordsT);
             points[iter]->setCoords(count, coordsT);
             count++;
             // makes the (0.5,0,0.5) atom
             coords[0] = coords[0];
-            coords[1] = coords[1] - (0.5 * latticeConstants.y);
-            coords[2] = coords[2] + (0.5 * latticeConstants.z);
+            coords[1] = coords[1] - (0.5f * latticeConstants.y);
+            coords[2] = coords[2] + (0.5f * latticeConstants.z);
             MatrixMath::Multiply3x3with3x1(gT, coords, coordsT);
             points[iter]->setCoords(count, coordsT);
             count++;
             // makes the (0,0.5,0.5) atom
-            coords[0] = coords[0] - (0.5 * latticeConstants.x);
-            coords[1] = coords[1] + (0.5 * latticeConstants.y);
+            coords[0] = coords[0] - (0.5f * latticeConstants.x);
+            coords[1] = coords[1] + (0.5f * latticeConstants.y);
+            coords[2] = coords[2];
+            MatrixMath::Multiply3x3with3x1(gT, coords, coordsT);
+            points[iter]->setCoords(count, coordsT);
+            count++;
+          }
+          if(basis == 3)
+          {
+            // (+0.25,+0.25,+0.25) for (0,0,0)
+            coords[0] = coords[0] + (0.25f * latticeConstants.x);
+            coords[1] = coords[1] - (0.25f * latticeConstants.y);
+            coords[2] = coords[2] - (0.25f * latticeConstants.z);
+            MatrixMath::Multiply3x3with3x1(gT, coords, coordsT);
+            points[iter]->setCoords(count, coordsT);
+            count++;
+            // (+0.25,+0.25,+0.25) for (0.5,0.5,0)
+            coords[0] = coords[0] + (0.5f * latticeConstants.x);
+            coords[1] = coords[1] + (0.5f * latticeConstants.y);
+            coords[2] = coords[2];
+            MatrixMath::Multiply3x3with3x1(gT, coords, coordsT);
+            points[iter]->setCoords(count, coordsT);
+            count++;
+            // (+0.25,+0.25,+0.25) for (0.5,0,0.5)
+            coords[0] = coords[0];
+            coords[1] = coords[1] - (0.5f * latticeConstants.y);
+            coords[2] = coords[2] + (0.5f * latticeConstants.z);
+            MatrixMath::Multiply3x3with3x1(gT, coords, coordsT);
+            points[iter]->setCoords(count, coordsT);
+            count++;
+            // (+0.25,+0.25,+0.25) for (0,0.5,0.5)
+            coords[0] = coords[0] - (0.5f * latticeConstants.x);
+            coords[1] = coords[1] + (0.5f * latticeConstants.y);
             coords[2] = coords[2];
             MatrixMath::Multiply3x3with3x1(gT, coords, coordsT);
             points[iter]->setCoords(count, coordsT);
@@ -281,6 +316,7 @@ void InsertAtoms::setupFilterParameters()
     choices.push_back("Simple Cubic");
     choices.push_back("Body Centered Cubic");
     choices.push_back("Face Centered Cubic");
+    choices.push_back("Cubic Diamond");
     parameter->setChoices(choices);
     parameter->setCategory(FilterParameter::Parameter);
     parameters.push_back(parameter);
@@ -529,9 +565,9 @@ void InsertAtoms::execute()
   }
 
   FloatVec3_t latticeConstants;
-  latticeConstants.x = m_LatticeConstants.x / 10000.0;
-  latticeConstants.y = m_LatticeConstants.y / 10000.0;
-  latticeConstants.z = m_LatticeConstants.z / 10000.0;
+  latticeConstants.x = m_LatticeConstants.x / 10000.0f;
+  latticeConstants.y = m_LatticeConstants.y / 10000.0f;
+  latticeConstants.z = m_LatticeConstants.z / 10000.0f;
 
   DataContainer::Pointer sm = getDataContainerArray()->getDataContainer(getSurfaceMeshFaceLabelsArrayPath().getDataContainerName());
   SIMPL_RANDOMNG_NEW()


### PR DESCRIPTION
* fix uninitialized variable

QVector<BoolArrayType::Pointer> m_InFeature was not defined past the value="start". This caused a seg fault crash when the feature number is high (>200). I'm guessing that the compiler preallocates the array for a few values past "start", which is why it does not crash when the total feature number is low. Fix this bug/type by changing the value to "iter"

* Add cubic crystal basis

Add cubic crystal which is basically adding an atom at the +1/4,+1/4,+1/4 location for each original atom.

* change from double to float

Signed-off-by: MicroClue <whsiao1995@hotmail.com>